### PR TITLE
Dev

### DIFF
--- a/modules/cold-extraction/README.md
+++ b/modules/cold-extraction/README.md
@@ -43,9 +43,9 @@ First, place the csv file adhering to the correct formats in a folder (by defaul
 
 * Please make sure to use EMPI and not MRN or Institution-specific patient identifiers.
 
-* Please include a header for the csv, such as "PatientID,AccessionNumber", as otherwise the first line will be ignored.
+* Please include a header for the csv, such as "PatientID,AccessionNumber". The first line is considered the header and will be ignored in the extractions.
 
-* Niffler can support up to 3 attributes in queries. However, please note that the extractions are done internally in either patient level (if the query is just based on PatientID) or study level (for example, a combination of PatientID and AccessionNumber). So, if your matching 3 DICOM keyword extraction is aimed at receiving only particular series, Niffler will in fact retrieve the entire studies of the relevant series. As of now, Niffler's granularity for on-demand extraction does not go to series or instances level.
+* Niffler can support up to 3 C-FIND DICOM keywords in queries. However, please note that the extractions are done internally in either patient level (if the query is just based on PatientID) or study level (for example, a combination of PatientID and AccessionNumber). So, if your matching 3 DICOM keyword extraction is aimed at receiving only particular series, Niffler will in fact retrieve the entire studies of the relevant series. Niffler's granularity for on-demand extraction does not go to series or instances level.
 
 The format examples:
 ```
@@ -92,8 +92,7 @@ Example: `python3 ./ColdDataRetriever.py --NumberOfQueryAttributes 1 --FirstAttr
 * *NumberOfQueryAttributes*: Can be 1, 2, or 3. By default, 1.
 
 * *FirstAttr*: Which should be the first attribute. By default, "PatientID". 
-  It is important to use the correct DICOM keywords such as, "PatientID", "AccessionNumber", "StudyInstanceUID", 
-  "StudyDescription", and "AcquisitionDate".
+  It is important to use the correct DICOM keywords such as, "PatientID", "AccessionNumber", "StudyInstanceUID", and "StudyDate".
   Please refer to the DICOM Standard for more information on the DICOM header attributes/keywords.
   Please note, the correct keyword is "AccessionNumber" and not "Accession" or "Accessions". Similarly, it is "PatientID" - neither "EMPI" nor "Patient-ID" (although they all are indeed the same in practice).
   
@@ -107,7 +106,7 @@ Example: `python3 ./ColdDataRetriever.py --NumberOfQueryAttributes 1 --FirstAttr
 
 * *ThirdIndex*: Set the CSV column index of third Attribute. By default, 2. This field is ignored when NumberOfQueryAttributes is 1 or 2.
 
-* *DateFormat*: DateFormat can range from %Y%m%d, %m/%d/%y, %m-%d-%y, %%m%d%y, etc. This field is ignored for extractions that do not use a Date as one of their extraction attributes. Currently supported date types are: StudyDate, AcquisitionDate, and SeriesDate. Leave this entry unmodified for such cases. The default is %Y%m%d and works for most cases.
+* *DateFormat*: DateFormat can range from %Y%m%d, %m/%d/%y, %m-%d-%y, %%m%d%y, etc. This field is ignored for extractions that do not use a Date as one of their extraction attributes. We have tested with StudyDate. Leave this entry unmodified for such cases. The default is %Y%m%d and works for most cases.
 
 * *SendEmail*: Do you want to send an email notification when the extraction completes? The default is true. You may disable this if you do not want to receive an email upon the completion.
 


### PR DESCRIPTION
When running niffler on the CBIS-DDSM dataset a strange error occurs caused by the fix_mismatch function. Some tags have a VR (Variable representation usually string, IntegerString, DecimalString ) as None instead of IS, PN, DS. When attempting to fix the mismatch the original approach tried to apply the translation using the tags VR. Since it is None an error occurs. Pydicom is able to handle these cases by itself so instead of forcing a fix I add a simple check that "skips" dealing with VRS that are None.