### PR TITLE
Bump log4j-core from 2.13.2 to 2.15.0 in /modules/app-layer

### DIFF
--- a/modules/app-layer/pom.xml
+++ b/modules/app-layer/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.13.2</version>
+			<version>2.15.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Bumps log4j-core from 2.13.2 to 2.15.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>