### PR TITLE
Ensure the number of splits is less than the number of DICOM files

### DIFF
--- a/modules/png-extraction/ImageExtractor.py
+++ b/modules/png-extraction/ImageExtractor.py
@@ -366,6 +366,9 @@ def execute(pickle_file, dicom_home, output_directory, print_images, print_only_
     else:
         filelist=glob.glob(file_path, recursive=True) # search the folders at the depth we request and finds all dicoms
         pickle.dump(filelist,open(pickle_file,'wb'))
+    # if number of files get more than number of split than
+    if len(filelist) < no_splits:
+        no_splits = len(filelist)
     file_chunks = np.array_split(filelist,no_splits)
     logging.info('Number of dicom files: ' + str(len(filelist)))
 


### PR DESCRIPTION
Now we  consider that if SplitChunks is greater than no of .dcm file then SplitChunks is equal Number of .dcm files.