### PR TITLE
Remove else statement in metadata extraction. 

### DIFF
--- a/modules/png-extraction/ImageExtractor.py
+++ b/modules/png-extraction/ImageExtractor.py
@@ -182,9 +182,8 @@ def extract_headers(f_list_elem):
     if len(kv) > dicom_tags_limit:
         logging.debug(str(len(kv)) + " dicom tags produced by " + ff)
         copyfile(ff, output_directory + '/failed-dicom/5/' + os.path.basename(ff))
-    else:
-        kv.append(('file', f_list_elem[1]))  # adds my custom field with the original filepath
-        kv.append(('has_pix_array', c))  # adds my custom field with if file has image
+    kv.append(('file', f_list_elem[1]))  # adds my custom field with the original filepath
+    kv.append(('has_pix_array', c))  # adds my custom field with if file has image
     if c:
         # adds my custom category field - useful if classifying images before processing
         kv.append(('category', 'uncategorized'))


### PR DESCRIPTION
Prevents the existence of nan entries in the metadata file. Solves problem raised in issue #351 . 