### PR TITLE
Fix syntax error in nifti file path definition

### DIFF
--- a/modules/nifti-extraction/ImageExtractorNifti.py
+++ b/modules/nifti-extraction/ImageExtractorNifti.py
@@ -203,7 +203,7 @@ def extract_images(filedata, i, nifti_destination, flattened_to_level, failed, i
             os.makedirs(nifti_destination + folderName,exist_ok=True)
 
 
-        niftifile = nifti_destination+folderName + '/' ID1 +'_' +ID2 +'_' +ID3 + '.nii.gz'
+        niftifile = nifti_destination+folderName + '/' +ID1 +'_' +ID2 +'_' +ID3 + '.nii.gz'
         dicom2nifti.dicom_series_to_nifti(str(filedata.iloc[i].loc['file']),niftifile)
         filemapping = filedata.iloc[i].loc['file'] + ',' + niftifile + '\n'
     except AttributeError as error:


### PR DESCRIPTION
Issue #384 has been resolved by inserting a '+' sign that was missing before ID1 at line 206, resulting in the proper definition of the nifti file path.

@pradeeban 