### PR TITLE
Containerizing meta-extraction module

### DIFF
--- a/modules/meta-extraction/Dockerfile
+++ b/modules/meta-extraction/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.10.10-bullseye
+
+# install JRE for DCM4CHE
+RUN set -eux; \
+    apt update && \
+    apt install -y openjdk-11-jre
+
+# install DCM4CHE
+RUN set -eux; \
+    cd /opt; \
+    curl -L https://sourceforge.net/projects/dcm4che/files/dcm4che3/5.22.5/dcm4che-5.22.5-bin.zip/download \
+         -o dcm4che-5.22.5-bin.zip; \
+    unzip dcm4che-5.22.5-bin.zip && \
+    rm dcm4che-5.22.5-bin.zip
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+# install required python packages
+RUN pip install -r requirements.txt
+
+# create default dicom storage directory
+RUN mkdir /opt/niffler-dicom-root
+
+CMD ["python", "MetadataExtractor.py"]

--- a/modules/meta-extraction/requirements.txt
+++ b/modules/meta-extraction/requirements.txt
@@ -1,0 +1,5 @@
+pymongo
+pydicom
+schedule
+pandas
+requests


### PR DESCRIPTION
An attempt to #349 for meta-extraction module.

This runs well on my tests so far. One improvement I can think of is perhaps to offload a couple of parameters such as _QueryAET_, _FilePath_, or _StorageFolder_ to environment variables instead of a json file to make configuring it more flexible, as “best practice” usually found in numerous container images. Please let me know if this is desired, I could perhaps put together a small script executed at startup that would rewrite system.json with values from environment variable, if exists.