### PR TITLE
Revert "Anonymization module"

### DIFF
--- a/modules/anonymization/Anonymize.py
+++ b/modules/anonymization/Anonymize.py
@@ -49,19 +49,22 @@ def initialize_config_and_execute(config_values):
     p3 = pathlib.PurePath(configs['MasterKeyPath'])
     mk_path = p3.as_posix()
 
-    p4 = pathlib.PurePath(configs['DicomTagDictPath'])
-    tag_dict_path = p4.as_posix()
+    p4 = pathlib.PurePath(configs['WhiteListPath'])
+    whitelist_path = p4.as_posix()
 
-    p5 = pathlib.PurePath(configs['KeepHeaderListPath'])
-    keep_header_list_path = p5.as_posix()
+    p5 = pathlib.PurePath(configs['DicomTagDictPath'])
+    tag_dict_path = p5.as_posix()
+
+    p6 = pathlib.PurePath(configs['KeepHeaderListPath'])
+    keep_header_list_path = p6.as_posix()
 
     keep_header_list = []
     with open(keep_header_list_path, 'r') as f:
         lines = f.readlines()
         keep_header_list.extend(lines)
 
-    p6 = pathlib.PurePath(configs['IgnoreDescPath'])
-    ignore_desc_path = p6.as_posix()
+    p7 = pathlib.PurePath(configs['IgnoreDescPath'])
+    ignore_desc_path = p7.as_posix()
 
     ignoreDesc = []
     with open(ignore_desc_path, 'r') as f:
@@ -128,7 +131,7 @@ def initialize_config_and_execute(config_values):
         os.makedirs(failed + "/5")
 
     # Load the Master Key
-    Anon = EmoryAnon(mk_path, tag_dict_path)
+    Anon = EmoryAnon(mk_path, whitelist_path, tag_dict_path)
     
     logging.info("------- Values Initialization DONE -------")
     final_res = execute(Anon, pickle_file, dicom_home, output_directory, print_png, print_dicom, print_only_common_headers, depth,
@@ -591,6 +594,7 @@ if __name__ == "__main__":
     ap.add_argument("--DICOMHome", default=niffler['DICOMHome'])
     ap.add_argument("--OutputDirectory", default=niffler['OutputDirectory'])
     ap.add_argument("--MasterKeyPath", default=niffler['MasterKeyPath'])
+    ap.add_argument("--WhiteListPath", default=niffler['WhiteListPath'])
     ap.add_argument("--DicomTagDictPath", default=niffler['DicomTagDictPath'])
     ap.add_argument("--Depth", default=niffler['Depth'])
     ap.add_argument("--BatchSize", default=niffler['BatchSize'])

--- a/modules/anonymization/config.json
+++ b/modules/anonymization/config.json
@@ -1,20 +1,21 @@
 {
-	"DICOMHome": "/PATH/TO/DICOM/DIR/",
-	"OutputDirectory": "/PATH/TO/OUTPUT/DIR/",
+	"DICOMHome": "/home/zzaiman/working_zz/BrainHealth/cold_extraction",
+	"OutputDirectory": "/home/zzaiman/working_zz/BrainHealth/anon_pipeline",
 	"MasterKeyPath" : "/home/Anonymization/PHIAnon",
+	"WhiteListPath" : "/home/Anonymization/textAnon/whitelist.csv",
 	"DicomTagDictPath" : "DICOMTagDict.csv",
 	"IgnoreDescPath" : "ignore.txt",
 	"Depth": 3,
 	"BatchSize": 100000,
 	"PrintPng": false,
-	"PrintDicom" : true,
+	"PrintDicom" : false,
 	"Mammo" : false,
 	"CommonHeadersOnly": true,
 	"PublicHeadersOnly": true,
 	"SpecificHeadersOnly": false,
 	"FlattenedToLevel": "series",
 	"is16Bit":true,
-	"SendEmail": false,
+	"SendEmail": true,
 	"KeepHeaderListPath" : "keepheaderlist.txt",
-	"YourEmail": ""
+	"YourEmail": "zzaiman@emory.edu"
 }


### PR DESCRIPTION
Reverts Emory-HITI/Niffler#399. `whitelist.csv` is no longer used, but is currently necessary for the `EmoryAnon()` class. Reverting changes until it is removed/made optional in `HITI-anon-internal`.